### PR TITLE
Fix WARNING! Your environment specifies an invalid locale error

### DIFF
--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -8,8 +8,10 @@
     - curl
     - locales
     - apt-transport-https
+    - language-pack-en
     - sshpass
 
+# See https://www.pixelflush.com/blog/2013/03/29/fix-locale-setting-on-ubuntu-ec2-instances/
 - name: Configure Locale as en_US.UTF-8
   locale_gen:
     name: en_US.UTF-8


### PR DESCRIPTION
See https://www.pixelflush.com/blog/2013/03/29/fix-locale-setting-on-ubuntu-ec2-instances/


``` bash
WARNING! Your environment specifies an invalid locale.
 The unknown environment variables are:
   LC_CTYPE=UTF-8 LC_ALL=
 This can affect your user experience significantly, including the
 ability to manage packages. You may install the locales by running:

   sudo apt-get install language-pack-UTF-8
     or
   sudo locale-gen UTF-8

To see all available language packs, run:
   apt-cache search "^language-pack-[a-z][a-z]$"
To disable this message for all users, run:
   sudo touch /var/lib/cloud/instance/locale-check.skip
```