### PR TITLE
Install ruby >= 2.4 on the DevSecOps-Box VM (fixes #76)

### DIFF
--- a/provisioning/devsecops-box.yml
+++ b/provisioning/devsecops-box.yml
@@ -16,7 +16,7 @@
        
   vars:
     # Inspec
-    ruby_version: 'ruby-2.3.1'
+    ruby_version: 'ruby-2.4.6'
     rvm1_rubies: ['{{ ruby_version }}']
     rvm1_user: 'root'
     rvm1_install_path: '/usr/local/rvm'


### PR DESCRIPTION
This resolves the issue in #76 and results in a successful provision of all boxes with a simple `vagrant up`.